### PR TITLE
Avoid usage of __cxa_thread_atexit_impl from glibc

### DIFF
--- a/src/cxa_thread_atexit.cpp
+++ b/src/cxa_thread_atexit.cpp
@@ -6,6 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+/** This file was edited for ClickHouse.
+  * This is needed to avoid linking with "__cxa_thread_atexit_impl" function, that require too new (2.18) glibc library.
+  *
+  * Note: "__cxa_thread_atexit_impl" may provide sophisticated implementation to correct destruction of thread-local objects,
+  * that was created in different DSO. Read https://sourceware.org/glibc/wiki/Destructor%20support%20for%20thread_local%20variables
+  * We simply don't need this implementation, because we don't use thread-local objects from different DSO.
+  */
+
 #include "abort_message.h"
 #include "cxxabi.h"
 #include <__threading_support>
@@ -21,15 +29,6 @@ namespace __cxxabiv1 {
 
   using Dtor = void(*)(void*);
 
-  extern "C"
-#ifndef HAVE___CXA_THREAD_ATEXIT_IMPL
-  // A weak symbol is used to detect this function's presence in the C library
-  // at runtime, even if libc++ is built against an older libc
-  _LIBCXXABI_WEAK
-#endif
-  int __cxa_thread_atexit_impl(Dtor, void*, void*);
-
-#ifndef HAVE___CXA_THREAD_ATEXIT_IMPL
 
 namespace {
   // This implementation is used if the C library does not provide
@@ -108,13 +107,7 @@ namespace {
 
 extern "C" {
 
-  _LIBCXXABI_FUNC_VIS int __cxa_thread_atexit(Dtor dtor, void* obj, void* dso_symbol) throw() {
-#ifdef HAVE___CXA_THREAD_ATEXIT_IMPL
-    return __cxa_thread_atexit_impl(dtor, obj, dso_symbol);
-#else
-    if (__cxa_thread_atexit_impl) {
-      return __cxa_thread_atexit_impl(dtor, obj, dso_symbol);
-    } else {
+  _LIBCXXABI_FUNC_VIS int __cxa_thread_atexit_impl(Dtor dtor, void* obj, void* dso_symbol) throw() {
       // Initialize the dtors std::__libcpp_tls_key (uses __cxa_guard_*() for
       // one-time initialization and __cxa_atexit() for destruction)
       static DtorsManager manager;
@@ -137,8 +130,11 @@ extern "C" {
       dtors = head;
 
       return 0;
-    }
-#endif // HAVE___CXA_THREAD_ATEXIT_IMPL
+  }
+
+  int __attribute__((__weak__)) __cxa_thread_atexit(Dtor dtor, void* obj, void* dso_symbol) throw()
+  {
+      return __cxa_thread_atexit_impl(dtor, obj, dso_symbol);
   }
 
 } // extern "C"

--- a/src/cxa_thread_atexit.cpp
+++ b/src/cxa_thread_atexit.cpp
@@ -103,7 +103,6 @@ namespace {
   };
 } // namespace
 
-#endif // HAVE___CXA_THREAD_ATEXIT_IMPL
 
 extern "C" {
 
@@ -132,7 +131,7 @@ extern "C" {
       return 0;
   }
 
-  int __attribute__((__weak__)) __cxa_thread_atexit(Dtor dtor, void* obj, void* dso_symbol) throw()
+  int __cxa_thread_atexit(Dtor dtor, void* obj, void* dso_symbol) throw()
   {
       return __cxa_thread_atexit_impl(dtor, obj, dso_symbol);
   }


### PR DESCRIPTION
We already have this trick inside our `glibc-compatibility` library.
Now it is moved directly to libc++abi.